### PR TITLE
Add ability to pass arguments and change the executable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,30 @@ You can also supply an array to set multiple environment variables:
   });
 ```
 
+## Arguments and executable path
+
+If you want to pass some arguments to your script, you can specify a string with comma separated values:
+
+```js
+  var svc = new Service({
+    name:'Hello World',
+    description: 'The nodejs.org example web server.',
+    script: '/path/to/helloworld.js',
+    scriptArgs: '-v,filename'
+  });
+```
+
+You can also specify the path of you Node.js executable. It is mostly useful if you want to use a Coffeescript program:
+
+```js
+  var svc = new Service({
+    name:'Hello World',
+    description: 'The nodejs.org example web server.',
+    script: '/path/to/helloworld.js',
+    execPath: '/usr/bin/coffee'
+  });
+```
+
 ## Cleaning Up: Uninstall a Service
 
 Uninstalling a previously created service is syntactically similar to installation.

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -216,6 +216,28 @@ var daemon = function(config) {
       value: config.script !== undefined ? require('path').resolve(config.script) : null
     },
 
+    /**
+     * @cfg {String} scriptArgs
+     * The arguments you want to pass to your script. Comma separated.
+     */
+    scriptArgs: {
+      enumerable: true,
+      writable: true,
+      configurable: false,
+      value: config.scriptArgs || ""
+    },
+
+    /**
+     * @cfg {String} execPath
+     * The path to your Node.js command.
+     */
+    execPath: {
+      enumerable: true,
+      writable: true,
+      configurable: false,
+      value: config.execPath || null
+    },
+
 		/**
 		 * @cfg {String} [logpath=/Library/Logs/node-scripts]
 		 * The root directory where the log will be stored.
@@ -525,6 +547,8 @@ var daemon = function(config) {
   // Generate wrapper code arguments
 	var args = [
 	  '-f','"'+this.script.trim()+'"',
+    '--args','"'+this.scriptArgs.trim()+'"',
+    '--execPath','"'+this.execPath.trim()+'"',
     '-l','"'+this.outlog.trim()+'"',
     '-e','"'+this.errlog.trim()+'"',
     '-t','"'+this.label.trim()+'"',

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -12,6 +12,10 @@ var optimist = require('optimist'),
           return exists;
         });
       })
+      .demand('args')
+      .describe('args','Arguments to pass to your script. Comma separated.')
+      .demand('execPath')
+      .describe('execPath','The path of the executable use to run your script.')
       .demand('log')
       .alias('l','log')
       .describe('log','The absolute path of the log file.')
@@ -49,6 +53,8 @@ var optimist = require('optimist'),
     //log = new Logger(argv.e == undefined ? argv.l : {source:argv.l,eventlog:argv.e}),
     fork = require('child_process').fork,
     script = p.resolve(argv.f),
+    scriptArgs = argv.args == undefined ? [] : argv.args.split(',')
+    execPath = argv.execPath == undefined ? require('process').execPath : argv.execPath
     wait = argv.w*1000,
     grow = argv.g+1,
     attempts = 0,
@@ -148,7 +154,7 @@ var launch = function(){
   starts += 1;
 
   // Fork the child process
-  child = fork(script,{env:process.env});
+  child = fork(script, scriptArgs, {env:process.env, execPath: execPath});
 
   // When the child dies, attempt to restart based on configuration
   child.on('exit',function(code){


### PR DESCRIPTION
Hi,

I have added two new arguments: `execPath` and `scriptArgs`.
- **execPath** allows to change the path of Node.js. Convenient to run Coffeescript scripts
- **scriptArgs** can be use to pass arguments to a Node.js script

You will also find a change that prevent the creation of `<script>_error.log` and `<script>-error.log` files

Please tell me if you want two different Pull Requests. 
Or anything you want me to change really :)

Thank you for this excellent project

Aurélien
