### PR TITLE
Accept dash in service name

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -98,7 +98,7 @@ var daemon = function(config) {
     label: {
     	enumerable: false,
     	get: function(){
-    		return this.name.replace(/[^a-zA-Z]+/gi,'').toLowerCase()
+    		return this.name.replace(/[^a-zA-Z\-]+/gi,'').toLowerCase()
     	}
     },
 

--- a/lib/systemv.js
+++ b/lib/systemv.js
@@ -313,7 +313,7 @@ var init = function(config){
 
   });
 
-  this._label = (config.name||'').replace(/[^a-zA-Z0-9]/,'').toLowerCase();
+  this._label = (config.name||'').replace(/[^a-zA-Z0-9\-]/,'').toLowerCase();
 
 };
 


### PR DESCRIPTION
I think dash is a common character in services names.
Beside it may helps finding cleaner name for services in some situations.
So the Pull Request propose to accept them in the name parameter.

Only that though...
We could probably go for underscore as well but if it was limited at first, there is probably a good reason for it.

Thank you