### PR TITLE
damon: fix this.script is undefined

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -205,7 +205,7 @@ var daemon = function(config) {
       enumerable: false,
       writable: true,
       configurable: false,
-      value: config.cwd || p.dirname(this.script)
+      value: config.cwd || p.dirname(config.script)
     },
 
     /**


### PR DESCRIPTION
When using default example:
```js
var Service = require('node-linux').Service;

  // Create a new service object
  var svc = new Service({
    name:'Hello World',
    description: 'The nodejs.org example web server.',
    script: '/path/to/helloworld.js'
  });
```
I see this error:
```js
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at Object.dirname (path.js:1324:5)
    at new daemon (/home/coderaiser/cloudcmd/node_modules/node-linux/lib/daemon.js:208:50)
    at Object.<anonymous> (/home/coderaiser/cloudcmd/bin/service.js:6:13)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.runMain (module.js:605:10)
```

Looks like `config` should be used instead of `this`.