### PR TITLE
systemd: throw -> emit('error')

### DIFF
--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -195,14 +195,14 @@ var init = function(config){
           if(!exists){
             me.generate(function(script){
               fs.writeFile(filepath,script,function(err){
-                if (err) throw err;
+                if (err) return me.emit('error', err);
                 fs.chmod(filepath,'755',function(_err){
-                  if (_err) throw _err;
+                  if (_err) return me.emit('error', _err);
 
                   var cmd = 'systemctl daemon-reload';
                   console.log('Running %s...', cmd);
                   exec(cmd,function(err){
-                    if (err) throw err;
+                    if (err) return me.emit('error', err);
                     me.emit('install');
                   });
 
@@ -280,7 +280,7 @@ var init = function(config){
         var cmd = 'systemctl start '+this.label;
         console.log('Running %s...', cmd);
         exec(cmd,function(err){
-          if (err) throw err;
+          if (err) return me.emit('error', err);
           /**
            * @event start
            * Fired when the #start method completes.


### PR DESCRIPTION
There is no way to `catch` exception that was `thrown` in asynchronous code.
Much better would be emitting errors, it is defined interface anyway.