### PR TITLE
Adding stoptimeout and stopparentfirst for clean shutdown support

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -96,6 +96,29 @@ var daemon = function(config) {
       configurable: false,
       value: config.group || 'root'
     },
+    
+    /**
+     * @cfg {Boolean} [stopparentfirst=false]
+     * Allow the service to shutdown cleanly.
+     */
+    stopparentfirst: {
+      enumerable: true,
+      writable: false,
+      configurable: false,
+      value: config.stopparentfirst
+    },
+    
+    /**
+     * @cfg {Number} [stoptimeout=30]
+     * How long to wait in seconds before force killing the application.
+     * This only takes effect when stopparentfirst is enabled.
+     */
+    stoptimeout: {
+      enumerable: true,
+      writable: false,
+      configurable: false,
+      value: config.stoptimeout || 30
+    },
 
     system: {
       enumerable: false,

--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -138,6 +138,8 @@ var init = function(config){
             env: '',
             created: new Date(),
             execpath: process.execPath,
+            stopparentfirst: config.stopparentfirst,
+            stoptimeout: config.stoptimeout
           };
 
           var _env = [];

--- a/lib/systemv.js
+++ b/lib/systemv.js
@@ -167,6 +167,7 @@ var init = function(config){
             env: '',
             created: new Date(),
             execpath: process.execPath,
+            stoptimeout: config.stoptimeout
           };
 
           // escape the double quotes in the wrappercode args here if we are on a redhat system

--- a/lib/templates/systemd/service
+++ b/lib/templates/systemd/service
@@ -8,6 +8,12 @@ SyslogIdentifier={{label}}
 User={{user}}
 Group={{group}}
 Environment={{env}}
+{{#stopparentfirst}}
+KillMode=process
+{{/stopparentfirst}}
+{{#stoptimeout}}
+TimeoutStopSec={{stoptimeout}}
+{{/stoptimeout}}
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/templates/systemv/debian
+++ b/lib/templates/systemv/debian
@@ -66,6 +66,7 @@ INIT_SCRIPT_NAME=`basename $THIS_ARG`
 INIT_SCRIPT_NAME_NOEXT=${INIT_SCRIPT_NAME%.*}
 PIDFILE="$LOCAL_VAR_RUN/$INIT_SCRIPT_NAME_NOEXT.pid"
 SCRIPTNAME=/etc/init.d/$INIT_SCRIPT_NAME
+STOPTIMEOUT={{stoptimeout}}
 
 # Exit if the package is not installed
 [ -x "$DAEMON" ] ||  { echo "can't find Node.js ($DAEMON)"  >&2; exit 0; }
@@ -147,7 +148,7 @@ do_stop()
   #   2 if daemon could not be stopped
   #   other if a failure occurred
   
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --chuid $NODEUSER --name $LABEL
+  start-stop-daemon --stop --quiet --retry=TERM/$STOPTIMEOUT/KILL/5 --pidfile $PIDFILE --chuid $NODEUSER --name $LABEL
   RETVAL="$?"
   
   #[ "$VERBOSE" != no ] && [ "$RETVAL" = 1 ] && log_daemon_msg  "  --->  SIGKILL failed => hardkill $DESC" "$INIT_SCRIPT_NAME_NOEXT"

--- a/lib/templates/systemv/redhat
+++ b/lib/templates/systemv/redhat
@@ -36,8 +36,16 @@ do_stop()
   echo -n "Stopping $LABEL:"
   PID=`cat ${PIDFILE}`
   kill $PID > /dev/null
+  TIMEOUT={{stoptimeout}}
   # wait for process to exit
-  while kill -0 $PID 2>/dev/null; do sleep 1;done;
+  # if waiting longer than the timeout send a SIGKILL
+  while kill -0 $PID 2>/dev/null; do 
+    if [ $TIMEOUT -lte 0 ]; then
+      kill -9 $PID
+    fi
+    sleep 1;
+    ((TIMEOUT--));
+  done;
   if [ -f ${LOCK_FILE} ] ; then
     rm ${LOCK_FILE}
   fi

--- a/lib/templates/systemv/redhat
+++ b/lib/templates/systemv/redhat
@@ -40,8 +40,9 @@ do_stop()
   # wait for process to exit
   # if waiting longer than the timeout send a SIGKILL
   while kill -0 $PID 2>/dev/null; do 
-    if [ $TIMEOUT -lte 0 ]; then
+    if [ $TIMEOUT -le 0 ]; then
       kill -9 $PID
+      echo "Process didn't exit before timeout, sent SIGKILL"
     fi
     sleep 1;
     ((TIMEOUT--));

--- a/lib/templates/systemv/redhat
+++ b/lib/templates/systemv/redhat
@@ -36,6 +36,8 @@ do_stop()
   echo -n "Stopping $LABEL:"
   PID=`cat ${PIDFILE}`
   kill $PID > /dev/null
+  # wait for process to exit
+  while kill -0 $PID 2>/dev/null; do sleep 1;done;
   if [ -f ${LOCK_FILE} ] ; then
     rm ${LOCK_FILE}
   fi

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -169,6 +169,9 @@ var launch = function(){
       console.error(argv.f+' exited with error code '+code);
       process.exit();
       server.unref();
+    } else if (forcekill) {
+      process.exit();
+      server.unref();
     }
 
     delete child.pid;
@@ -183,7 +186,6 @@ process.on('exit',function(){
   console.log("Got exit signal, closing down");
   forcekill = true;
   child.kill();
-  process.exit();
 });
 
 // Killing the wrapper does not kill the child node process without this handler
@@ -191,7 +193,6 @@ process.on('SIGTERM',function(){
   console.log("Got SIGTERM, closing down");
   forcekill = true;
   child.kill();
-  process.exit();
 });
 
 process.on('uncaughtException', function(err) {


### PR DESCRIPTION
This is a followon from the node-windows pull request.

I have not really tested the debian systemv path yet. I will probably get to that on Monday. But it is a really small change using the existing daemon script so I thought I would get this started.

The stopparentfirst argument doesn't seem applicable to the systemv path, as that is the default behavior.