### PR TITLE
add working directory option to systemd scripts

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -676,6 +676,7 @@ var daemon = function(config) {
 
   opts.name = this.label;
   opts.description = this.description;
+  opts.cwd = this.cwd;
   opts.author = this.author;
   opts.env = this.EnvironmentVariables;
   opts.usewrapper = config.usewrapper;

--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -130,6 +130,7 @@ var init = function(config){
             script: p.join(__dirname,'wrapper.js'),
             nodescript: config.script || '',
             wrappercode: (config.wrappercode || ''),
+            cwd: config.cwd,
             description: config.description,
             user: config.user || 'root',
             group: config.group || 'root',

--- a/lib/templates/systemd/service
+++ b/lib/templates/systemd/service
@@ -2,6 +2,7 @@
 Description={{description}}
 
 [Service]
+WorkingDirectory={{cwd}}
 ExecStart={{execpath}} {{nodescript}}
 Restart=always
 SyslogIdentifier={{label}}

--- a/lib/templates/systemd/service-wrapper
+++ b/lib/templates/systemd/service-wrapper
@@ -2,6 +2,7 @@
 Description={{description}}
 
 [Service]
+WorkingDirectory={{cwd}}
 ExecStart={{execpath}} {{script}} {{{wrappercode}}}
 Restart=always
 SyslogIdentifier={{label}}


### PR DESCRIPTION
The versions before this one do not support actual specification of the working directory of the service. This is an implementation that does just that