### PR TITLE
please add WorkingDirectory to systemd

### DIFF
--- a/lib/systemd.js
+++ b/lib/systemd.js
@@ -136,6 +136,7 @@ var init = function(config){
             pidroot: config.pidroot || '/var/run',
             logroot: config.logroot || '/var/log',
             env: '',
+	    path: config.path || process.cwd(),
             created: new Date(),
             execpath: process.execPath,
           };

--- a/lib/templates/systemd/service
+++ b/lib/templates/systemd/service
@@ -2,6 +2,7 @@
 Description={{description}}
 
 [Service]
+WorkingDirectory={{path}}
 ExecStart={{execpath}} {{nodescript}}
 Restart=always
 SyslogIdentifier={{label}}


### PR DESCRIPTION
When using cluster, child processes die at startup, since systemd requires you to set the working directory in the service file.