### PR TITLE
Fix inconsistency between node-linux, node-mac, node-windows.

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -180,10 +180,12 @@ var daemon = function(config) {
      * @readonly
      */
     exists: {
-     	enumerable: true,
-     	value: function(){
-     		return this.generator.exists;
-     	}
+       enumerable: true,
+       value: function(){
+         if (this.generator) {
+           return this.generator.exists;
+         }
+       }
     },
 
     /**


### PR DESCRIPTION
The `exists` API is in the case of node-linux a function and so
a call is needed, whereas it is a property in node-mac and node-windows.

This is an attempt to fix this inconsistency.
I guess it wasn't a getter / property because the code later just tries to evaluate all properties by iterating over them and adding them to he opts object. While the `exists` property was a getter this would have thrown errors that `this.generator` is undefined.

This could be fixed in various ways:
- fix node-mac and node-linux to adapt that `exists` property is a function
- make node-linux `exists`  property a getter and:
  - Just return `undefined` if `this.generator` is `undefined`
  - map opts by hand instead of iterating overall

- I decided to change node-linux instead of two modules.
- i decided against mapping all the values by hand as its easier to overlook one and maybe adding one later might also be overlooked
- i just return undefined in the exists call, this is only the case for the short period of time of sync calls until the creation of `daemon` is done.

Version needs to be raised as this might be a breaking change.